### PR TITLE
Modified rollbar.attach to allow .Last() function to run

### DIFF
--- a/R/rollbar.R
+++ b/R/rollbar.R
@@ -13,7 +13,7 @@ rollbar.attach <- function() {
       }
 
       write("Execution halted", stderr())
-      q("no", status = 1, runLast = FALSE)
+      q("no", status = 1, runLast = TRUE)
     })
   }
 }


### PR DESCRIPTION
Currently the .Last() function cannot run since runLast is FALSE in rollbar.attach. This modifies rollbar.attach to allow the function to run