### PR TITLE
Modified rollbar error messages to display script directory

### DIFF
--- a/R/rollbar.R
+++ b/R/rollbar.R
@@ -5,7 +5,7 @@ rollbar.attach <- function() {
   if (!interactive()) {
     prev <- getOption("error")
     options(error = function() {
-      message <- geterrmessage()
+      message <- paste0(getwd(), ": ", geterrmessage())
       rollbar::rollbar.error(message)
 
       if (is.language(prev)) {


### PR DESCRIPTION
Having issues with determining the source for an error when multiple scripts have the same name. This PR prepends the current directory to the message. It assumes that the script is being executed from that directory (which is a reasonable assumption for most of our scripts, since we change the working directory before executing the script).